### PR TITLE
🔧 chore(ci): only auto-PR staging→master; bump actions; fix comment target

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -1,11 +1,10 @@
 name: Auto-PR
 
 on:
+  # Only staging pushes open the release PR; feature branches no longer
+  # auto-open a PR into staging.
   push:
-    branches-ignore:
-      - master
-      - main
-      - gh-readonly-queue/*
+    branches: [staging]
 
 permissions:
   contents: write
@@ -20,10 +19,9 @@ jobs:
   # ────────────────────────────────────────────────────────────────
   pull-request-master:
     name: Create Pull Request to Master
-    if: github.ref == 'refs/heads/staging'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -93,117 +91,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: gh pr edit staging --body-file pr_body.md
-
-  # ────────────────────────────────────────────────────────────────
-  # FEATURE BRANCH → STAGING draft PR.
-  # On every push to a non-staging, non-master branch, ensure there's
-  # an open draft PR from the branch into staging with an AI-generated
-  # description (or a fallback list of commits if ANTHROPIC_API_KEY is
-  # not configured).
-  # ────────────────────────────────────────────────────────────────
-  pull-request-staging:
-    name: Create Pull Request to Staging
-    if: github.ref != 'refs/heads/staging' && github.ref != 'refs/heads/master'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-
-      - name: Extract branch info
-        id: branch
-        run: .github/scripts/extract-branch-info.sh --branch "${GITHUB_REF#refs/heads/}"
-
-      - name: Set PR emoji
-        id: emoji
-        run: |
-          case "${{ steps.branch.outputs.pr_prefix }}" in
-            feat)
-              echo "emoji=✨" >> $GITHUB_OUTPUT
-              ;;
-            fix)
-              echo "emoji=🐛" >> $GITHUB_OUTPUT
-              ;;
-            chore)
-              echo "emoji=🔧" >> $GITHUB_OUTPUT
-              ;;
-            docs)
-              echo "emoji=📚" >> $GITHUB_OUTPUT
-              ;;
-            *)
-              echo "emoji=🔄" >> $GITHUB_OUTPUT
-              ;;
-          esac
-
-      - name: Check for existing PR
-        id: check_pr
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: .github/scripts/check-pr-exists.sh --base staging --head ${{ github.ref_name }}
-
-      - name: Create PR to Staging
-        if: steps.check_pr.outputs.result == '0'
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          gh pr create \
-            --title "${{ steps.emoji.outputs.emoji }} ${{ steps.branch.outputs.pr_prefix }}: ${{ steps.branch.outputs.feature_name }}" \
-            --body "🤖 Generating PR description..." \
-            --base staging \
-            --head "${{ steps.branch.outputs.branch_name }}" \
-            --draft
-
-      - name: Collect changes
-        if: steps.check_pr.outputs.result == '0'
-        run: .github/scripts/collect-git-changes.sh --base origin/staging --head ${{ steps.branch.outputs.branch_name }} --output-commits commits.txt --output-diff-stat diff_stat.txt --output-diff-content diff_content.txt --diff-content-limit 15000 --allow-empty
-
-      - name: Generate PR description with Claude
-        if: steps.check_pr.outputs.result == '0'
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: |
-          COMMITS=$(cat commits.txt)
-          DIFF_STAT=$(cat diff_stat.txt)
-          DIFF_CONTENT=$(cat diff_content.txt)
-          BRANCH_NAME="${{ steps.branch.outputs.branch_name }}"
-
-          cat > prompt.txt <<EOF
-          Write a PR description for branch '${BRANCH_NAME}' merging into staging.
-
-          Based on the commits and code diff below, write a clear description:
-          - Start with 1-2 sentences explaining what this PR does
-          - List the key changes as bullet points
-          - Use relevant emojis to make the description more engaging (✨ for features, 🐛 for fixes, ⚡ for improvements, 🔧 for chores, 📚 for docs, etc.)
-          - Mention anything reviewers should pay attention to
-
-          Commits:
-          ${COMMITS}
-
-          Files changed:
-          ${DIFF_STAT}
-
-          Code diff (truncated):
-          ${DIFF_CONTENT}
-
-          Write the PR description in markdown. No headers, just the content:
-          EOF
-
-          .github/scripts/call-claude-api.sh \
-            --prompt-file prompt.txt \
-            --output pr_body.md \
-            --fallback "Changes from ${BRANCH_NAME}.
-
-          $(cat commits.txt | sed 's/^/- /')"
-
-      - name: Update PR description
-        if: steps.check_pr.outputs.result == '0'
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: gh pr edit "${{ steps.branch.outputs.branch_name }}" --body-file pr_body.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
       - uses: oven-sh/setup-bun@v2
@@ -48,8 +48,8 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
       - uses: oven-sh/setup-bun@v2
@@ -69,8 +69,8 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
       - uses: oven-sh/setup-bun@v2
@@ -96,8 +96,8 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
       - uses: oven-sh/setup-bun@v2
@@ -174,20 +174,31 @@ jobs:
           echo "<sub>updated for \`${HEAD_SHA:0:7}\` · <a href=\"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\">run #$GITHUB_RUN_NUMBER</a></sub>" >> comment.md
 
       - name: Post or update PR comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs')
             const body = fs.readFileSync('comment.md', 'utf8')
             const marker = '<!-- code-quality -->'
             const { owner, repo } = context.repo
-            const issue_number = context.payload.pull_request.number
-            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number })
-            const existing = comments.find(c => c.body && c.body.includes(marker))
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body })
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body })
+            // One branch can back several open PRs (e.g. fallow → staging and
+            // fallow → master). The triggering event only references one of
+            // them, so look them all up by head and post/update on each.
+            const branch = context.payload.pull_request.head.ref
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'open', head: `${owner}:${branch}`,
+            })
+            const targets = prs.length
+              ? prs.map(p => p.number)
+              : [context.payload.pull_request.number]
+            for (const issue_number of targets) {
+              const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number })
+              const existing = comments.find(c => c.body && c.body.includes(marker))
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body })
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number, body })
+              }
             }
 
       - name: Gate
@@ -213,8 +224,8 @@ jobs:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
       - uses: oven-sh/setup-bun@v2
@@ -261,8 +272,8 @@ jobs:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
       - uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
Follow-up to #78 (now merged). Three CI/workflow fixes, no app code touched.

### `auto-pr.yml` — stop auto-opening feature → staging PRs
- Removed the `pull-request-staging` job that opened a draft `<branch> → staging` PR on every feature-branch push (this is what created the confusing duplicate PR).
- Narrowed the trigger to `push: branches: [staging]`, so the **only** auto-PR is the `staging → master` release PR (kept as-is).

### `ci.yml` — latest action versions
- `actions/checkout` v6 → **v7**
- `actions/setup-node` v5 → **v6**
- `actions/github-script` v7 → **v9** (clears the *"Node 20 is being deprecated"* warning)
- (`oven-sh/setup-bun@v2`, `dopplerhq/cli-action@v4`, `actions/create-github-app-token@v3` already on latest major)

### `code-quality` — comment lands on the right PR
The sticky comment now posts/updates on **every open PR backed by the branch** (looked up by head), instead of only the single PR referenced by the triggering event — so a branch that backs more than one PR gets the comment on each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)